### PR TITLE
Adopt the new URL format for recent builds

### DIFF
--- a/is-older-version.mjs
+++ b/is-older-version.mjs
@@ -53,3 +53,11 @@ export const predatesChromeHeadlessShellAvailability = (version) => {
 	const predates = isOlderVersion(version, firstChromeHeadlessShellVersion);
 	return predates;
 };
+
+export const predatesNewUrlFormat = (version) => {
+	// Until we migrate additional assets (WIP), versions older than this
+	// are not yet available in the new storage bucket.
+	const firstVersionUsingNewUrlFormat = '121.0.6167.85';
+	const predates = isOlderVersion(version, firstVersionUsingNewUrlFormat);
+	return predates;
+};

--- a/url-utils.mjs
+++ b/url-utils.mjs
@@ -16,6 +16,8 @@
 
 import assert from 'node:assert';
 
+import {predatesNewUrlFormat} from './is-older-version.mjs';
+
 // Lorry download bucket labels.
 export const platforms = new Set([
 	'linux64',
@@ -34,6 +36,9 @@ export const binaries = new Set([
 export const makeDownloadUrl = ({ version, platform, binary = 'chrome' }) => {
 	assert(platforms.has(platform));
 	assert(binaries.has(binary));
-	const url = `https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${version}/${platform}/${binary}-${platform}.zip`;
+	const useLegacyUrlFormat = predatesNewUrlFormat(version);
+	const url = useLegacyUrlFormat
+		? `https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${version}/${platform}/${binary}-${platform}.zip`
+		: `https://storage.googleapis.com/chrome-for-testing-public/${version}/${platform}/${binary}-${platform}.zip`;
 	return url;
 };


### PR DESCRIPTION
In practice, this means replacing

    https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/

with

    https://storage.googleapis.com/chrome-for-testing-public/

Until all existing assets are migrated to the new storage bucket, we have to keep using the legacy URL format for older assets.

Issue: https://crbug.com/41490907