### PR TITLE
Generate metadata file for each version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ For historical reasons, `LATEST_RELEASE_` files containing fully qualified versi
 
 These can be used instead of the `latest-versions-per-milestone`, `latest-patch-versions-per-build`, and `last-known-good-versions` [JSON API endpoints](#json-api-endpoints) respectively.
 
+Additionally, each version from the
+(`known-good-versions-with-downloads.json`)[https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json]
+is published as a separate JSON file, for example,
+[`123.0.6309.0.json`](https://googlechromelabs.github.io/chrome-for-testing/123.0.6309.0.json).
+
 ## CLI utilities
 
 ### Find the latest Chrome versions across channels

--- a/generate-extra-json.mjs
+++ b/generate-extra-json.mjs
@@ -224,4 +224,4 @@ const writePerVersionFiles = async () => {
   }));
 };
 
-writePerVersionFiles();
+await writePerVersionFiles();

--- a/generate-extra-json.mjs
+++ b/generate-extra-json.mjs
@@ -216,3 +216,12 @@ await writeJsonFile(
 	'./data/latest-patch-versions-per-build-with-downloads.json',
 	addDownloads(latestPatchVersionsPerBuild, 'builds')
 );
+
+const writePerVersionFiles = async () => {
+  await Promise.all(addDownloads(knownGoodVersions, 'versions').versions.map((release) => {
+    const fileName = `./dist/${release.version}.json`;
+    return writeJsonFile(fileName, release);
+  }));
+};
+
+writePerVersionFiles();


### PR DESCRIPTION
This allows clients to find all metadata for a given version without the need to fetch the (larger) file with all versions.