### PR TITLE
Minify the per-version JSON files

### DIFF
--- a/generate-extra-json.mjs
+++ b/generate-extra-json.mjs
@@ -220,7 +220,7 @@ await writeJsonFile(
 const writePerVersionFiles = async () => {
   await Promise.all(addDownloads(knownGoodVersions, 'versions').versions.map((release) => {
     const fileName = `./dist/${release.version}.json`;
-    return writeJsonFile(fileName, release);
+    return writeMinifiedJsonFile(fileName, release);
   }));
 };
 

--- a/json-utils.mjs
+++ b/json-utils.mjs
@@ -23,6 +23,11 @@ export const readJsonFile = async (filePath) => {
 };
 
 export const writeJsonFile = async (filePath, data) => {
-	const json = JSON.stringify(data, null, '\t');
-	await fs.writeFile(filePath, `${json}\n`);
+	const json = `${JSON.stringify(data, null, '\t')}\n`;
+	await fs.writeFile(filePath, json);
+};
+
+export const writeMinifiedJsonFile = async (filePath, data) => {
+	const json = JSON.stringify(data);
+	await fs.writeFile(filePath, json);
 };


### PR DESCRIPTION
Other JSON files first get written to `./data`, and then minified copies of them are written to `./dist` as part of `npm run json`.

Since the new version-specific JSON files are written to `./dist` directly, we must minify them.