### PR TITLE
docs: linux package deps install use apt-get update

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Use [`@puppeteer/browsers`](https://pptr.dev/browsers-api/).
 
 ```sh
 unzip chrome-linux64.zip;
-apt update;
+apt-get update;
 while read pkg; do
   apt-get satisfy -y --no-install-recommends "${pkg}";
 done < chrome-linux64/deb.deps;


### PR DESCRIPTION
## Situation

The [README > FAQ](https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/README.md#faq) section [How to install the system-level dependencies required for archived linux64 binaries?](https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/README.md#how-to-install-the-system-level-dependencies-required-for-archived-linux64-binaries) shows a mixture of using `apt` and `apt-get` in the example script to install dependencies.

```shell
unzip chrome-linux64.zip;
apt update;
while read pkg; do
  apt-get satisfy -y --no-install-recommends "${pkg}";
done < chrome-linux64/deb.deps;
```

https://manpages.debian.org/stretch/apt/apt.8.en.html#SCRIPT_USAGE_AND_DIFFERENCES_FROM_OTHER_APT_TOOLS recommends using `apt-get` in scripts


This is already being used successfully in CircleCI scripts to install Chrome for Testing. See https://github.com/CircleCI-Public/browser-tools-orb/blob/main/src/scripts/install_chrome_for_testing.sh

## Change

Change `apt update` to `apt-get update` in the example script [How to install the system-level dependencies required for archived linux64 binaries?](https://github.com/GoogleChromeLabs/chrome-for-testing/blob/main/README.md#how-to-install-the-system-level-dependencies-required-for-archived-linux64-binaries)