### PR TITLE
Ensure dashboard version numbers align with API data

### DIFF
--- a/find-version.mjs
+++ b/find-version.mjs
@@ -42,30 +42,32 @@ const findVersionForChannel = async (channel = 'Stable') => {
 	const response = await fetch(apiEndpoint);
 	const data = await response.json();
 
-	let minVersion = `99999.99999.99999.99999`;
 	const versions = new Set();
 	for (const entry of data) {
 		const version = entry.version;
 		const revision = String(entry.chromium_main_branch_position);
 		versions.add(version);
 		versionsToRevisions.set(version, revision);
-		if (isOlderVersion(version, minVersion)) {
-			minVersion = version;
-		}
 	}
 
 	console.log(`Found versions:`, versions);
 
-	let desiredVersion = minVersion;
+	const sortedVersions = Array.from(versions).sort((a, b) => {
+		if (isOlderVersion(a, b)) return -1;
+		if (isOlderVersion(b, a)) return 1;
+		return 0;
+	});
+
+	let desiredVersion = sortedVersions[0];
 	let checked = null;
-	for (const version of versions) {
+	for (const version of sortedVersions) {
+		desiredVersion = version;
 		checked = await checkDownloadsForVersion(version);
 		console.log(
 			`Checking version ${version}…`,
 			checked.isOk ? '\u2705 OK' : '\u274C NOT OK',
 		);
 		if (checked.isOk) {
-			desiredVersion = version;
 			break;
 		}
 	}
@@ -74,11 +76,13 @@ const findVersionForChannel = async (channel = 'Stable') => {
 	result.version = desiredVersion;
 	result.revision = versionsToRevisions.get(desiredVersion);
 
-	for (const { binary, platform, url, status } of checked.downloads) {
-		result.downloads[binary].push({ platform, url, status });
-		console.log(url, status);
+	if (checked) {
+		for (const { binary, platform, url, status } of checked.downloads) {
+			result.downloads[binary].push({ platform, url, status });
+			console.log(url, status);
+		}
+		result.ok = checked.isOk;
 	}
-	result.ok = checked.isOk;
 
 	return result;
 };

--- a/generate-html.mjs
+++ b/generate-html.mjs
@@ -17,6 +17,7 @@
 import fs from 'node:fs/promises';
 
 import {
+	isOlderVersion,
 	predatesChromeDriverAvailability,
 	predatesChromeHeadlessShellAvailability,
 } from './is-older-version.mjs';
@@ -78,7 +79,11 @@ const render = (data) => {
 	const main = [];
 	for (const [channel, channelData] of Object.entries(data.channels)) {
 		const { version, revision, downloads } = channelData;
-		const isOk = channelData.ok;
+		const fallbackChannelData = lastKnownGoodVersions.channels[channel];
+		const fallbackVersion = fallbackChannelData.version;
+		const fallbackRevision = fallbackChannelData.revision;
+		const fallbackDownloads = fallbackChannelData.downloads;
+		const isOk = channelData.ok && !isOlderVersion(version, fallbackVersion);
 		if (isOk) {
 			summary.push(`
 				<tr class="status-ok">
@@ -88,9 +93,6 @@ const render = (data) => {
 					<td>${OK}
 			`);
 		} else {
-			const fallbackData = lastKnownGoodVersions.channels[channel];
-			const fallbackVersion = fallbackData.version;
-			const fallbackRevision = fallbackData.revision;
 			summary.push(`
 				<tr class="status-ok">
 					<th><a href="#${escapeHtml(channel.toLowerCase())}">${escapeHtml(channel)}</a>
@@ -116,10 +118,6 @@ const render = (data) => {
 				${renderDownloads(downloads, version)}
 			`);
 		} else {
-			const fallbackChannelData = lastKnownGoodVersions.channels[channel];
-			const fallbackVersion = fallbackChannelData.version;
-			const fallbackRevision = fallbackChannelData.revision;
-			const fallbackDownloads = fallbackChannelData.downloads;
 			main.push(`
 				<h2>${escapeHtml(channel)}</h2>
 				<p>Version: <code>${escapeHtml(fallbackVersion)}</code> (<code>r${escapeHtml(fallbackRevision)}</code>)</p>


### PR DESCRIPTION
This PR resolves a discrepancy where the HTML dashboard and the `last-known-good-versions` JSON API endpoints could diverge on the active channel version during early stable and staged platform rollouts.

### Root cause

1. **Premature milestone selection in `find-version.mjs`**: During early stable or staged rollouts across platforms (e.g. Windows and macOS receiving an early build while Linux remains on the prior milestone), the ChromiumDash API returns versions for both milestones. Because versions were iterated in insertion order (newest first) and CfT binaries for the newer version already exist in Google Cloud Storage, `find-version.mjs` selected the newer milestone prematurely before all platforms had migrated.
2. **Dashboard and API divergence**: When subsequent maintenance patches were released for the active stable milestone, `find-version.mjs` reported the patch version (e.g. M149). `generate-extra-json.mjs` preserved the higher version (M150) in `last-known-good-versions.json` due to its monotonic version guard (#198), while `generate-html.mjs` rendered the lower version directly from `dashboard.json` because its downloads succeeded.

### Changes

- **Sort detected versions ascending before availability checks** (find-version.mjs): Sort unique versions from oldest to newest using `isOlderVersion`. This ensures the lowest common version across platforms is selected as long as it remains available, while continuing to support fallback to newer builds for A/B rollout edge cases (#193). Also keeps `desiredVersion` and `checked` downloads synchronized if all availability checks fail.
- **Enforce consistency in dashboard rendering** (generate-html.mjs): Ensure the dashboard OK status check considers `!isOlderVersion(version, fallbackVersion)` so the primary status row cannot display a version older than what is recorded in `last-known-good-versions.json`.

### Verification

- Ran `npm run build` to verify all generation steps (`find`, `json`, `txt`, `render`) execute cleanly and produce consistent outputs across dashboard HTML and JSON endpoints.
- Formatted all code with `npm run format`.

Issue: #208
