### PR TITLE
perf: parallelize HEAD requests in checkDownloadsForVersion

### DIFF
--- a/url-utils.mjs
+++ b/url-utils.mjs
@@ -77,35 +77,36 @@ export const makeDownloadsForVersion = (version) => {
 export const checkDownloadsForVersion = async (version) => {
 	const downloads = makeDownloadsForVersion(version);
 
-	// Add `isOk` and `status` properties.
-	let hasFailure = false;
-	for (const download of downloads) {
-		const { binary, url } = download;
-		const response = await fetch(url, { method: 'head' });
-		const status = response.status;
-		if (status !== 200) {
-			const ignoreChromeDriver =
-				binary === 'chromedriver' && predatesChromeDriverAvailability(version);
-			const ignoreChromeHeadlessShell =
-				binary === 'chrome-headless-shell' &&
-				predatesChromeHeadlessShellAvailability(version);
-			const ignoreMojoJs =
-				binary === 'mojojs' && predatesMojoJsAvailability(version);
-			const ignore =
-				ignoreChromeDriver || ignoreChromeHeadlessShell || ignoreMojoJs;
-			if (ignore) {
-				// Do not consider missing ChromeDriver, chrome-headless-shell,
-				// or MojoJS assets a failure for versions predating their CfT
-				// release.
+	await Promise.all(
+		downloads.map(async (download) => {
+			const { binary, url } = download;
+			const response = await fetch(url, { method: 'head' });
+			const status = response.status;
+			download.status = status;
+			if (status !== 200) {
+				const ignoreChromeDriver =
+					binary === 'chromedriver' &&
+					predatesChromeDriverAvailability(version);
+				const ignoreChromeHeadlessShell =
+					binary === 'chrome-headless-shell' &&
+					predatesChromeHeadlessShellAvailability(version);
+				const ignoreMojoJs =
+					binary === 'mojojs' && predatesMojoJsAvailability(version);
+				const ignore =
+					ignoreChromeDriver || ignoreChromeHeadlessShell || ignoreMojoJs;
+				if (!ignore) {
+					// Do not consider missing ChromeDriver, chrome-headless-shell,
+					// or MojoJS assets a failure for versions predating their CfT
+					// release.
+					download.isOk = false;
+				}
 			} else {
-				download.isOk = false;
-				hasFailure = true;
+				download.isOk = true;
 			}
-		} else {
-			download.isOk = true;
-		}
-		download.status = status;
-	}
+		}),
+	);
+
+	const hasFailure = downloads.some((d) => d.isOk === false);
 	return {
 		downloads,
 		isOk: !hasFailure,


### PR DESCRIPTION
## What
Replaces the sequential `for` loop in `checkDownloadsForVersion` (`url-utils.mjs`) with `Promise.all` so all HEAD requests fire concurrently.

## Why
Each call issues 16-19 independent HEAD requests. Running them sequentially wastes the full RTT of every intermediate request. With up to 8 calls per CI run and ~100 ms average GCS RTT, the worst case is ~15 s of pure waiting reduced to roughly the slowest single response.

`hasFailure` moves from a mutable boolean accumulated inside the loop to a `.some()` pass after `Promise.all` resolves equivalent because `Promise.all` only resolves once every callback has set its `download.isOk`.

## Testing
`npm run check -- 152.0.7977.64` produces identical output before and after.

Issue: #216