### PR TITLE
fix: add missing `build` field to `latest-patch-versions-per-build` entries

### DIFF
--- a/generate-extra-json.mjs
+++ b/generate-extra-json.mjs
@@ -202,7 +202,7 @@ const prepareLatestPatchVersionsPerBuild = (knownGoodVersions) => {
 	};
 	const builds = result.builds;
 	for (const [partialVersion, entry] of map) {
-		builds[partialVersion] = entry;
+		builds[partialVersion] = { build: partialVersion, ...entry };
 	}
 	return result;
 };


### PR DESCRIPTION
Fixes #219 

## What

Adds a `build` field to each entry in `latest-patch-versions-per-build.json` and `latest-patch-versions-per-build-with-downloads.json`, making them consistent with the parallel `latest-versions-per-milestone.json` endpoint
which already includes a `milestone` field in every entry.

**Before**
```json
"113.0.5672": {
  "version": "113.0.5672.63",
  "revision": "1421455"
}
```

**After**
```json
"113.0.5672": {
  "build": "113.0.5672",
  "version": "113.0.5672.63",
  "revision": "1421455"
}
```

## Why

The two endpoints serve the same structural role look up the best known version for a given key but behave differently when destructured:

```js
// latest-versions-per-milestone.json works fine
const { milestone, version, revision } = data.milestones['113'];
// milestone = '113'

// latest-patch-versions-per-build.json build prefix is lost
const { version, revision } = data.builds['113.0.5672'];
// no build field consumer must track the key separately
```

The root cause is in `prepareLatestPatchVersionsPerBuild` in `generate-extra-json.mjs`. When building the result, entries are stored directly from `knownGoodVersions` (which only has `version` and `revision`) without adding the build prefix unlike `updateLatestVersionsPerMilestone` which explicitly includes `milestone` when creating each entry.